### PR TITLE
génération des certifications sans les entetes ---BEGIN/END CERTIFICA…

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,17 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Cube43\\\\Component\\\\Ebics\\\\X509\\\\DefaultX509OptionGenerator\\:\\:getStart\\(\\) should return DateTimeImmutable but returns DateTimeImmutable\\|false\\.$#"
+			message: "#^Parameter \\#1 \\$str of function base64_encode expects string, string\\|false given\\.$#"
 			count: 1
-			path: src/X509/DefaultX509OptionGenerator.php
-
-		-
-			message: "#^Method Cube43\\\\Component\\\\Ebics\\\\X509\\\\DefaultX509OptionGenerator\\:\\:getEnd\\(\\) should return DateTimeImmutable but returns DateTimeImmutable\\|false\\.$#"
-			count: 1
-			path: src/X509/DefaultX509OptionGenerator.php
-
-		-
-			message: "#^Parameter \\#1 \\$rawdigest of closure expects string, string\\|false given\\.$#"
-			count: 1
-			path: tests/E2e/Command/E2eTestBase.php
+			path: src/Command/INICommand.php
 

--- a/src/X509/X509Generator.php
+++ b/src/X509/X509Generator.php
@@ -49,7 +49,8 @@ class X509Generator
 
         $result = $x509->sign($issuer, $x509, 'sha256WithRSAEncryption');
 
-        return $x509->saveX509($result);
+        //  return $x509->saveX509($result);
+        return $x509->saveX509($result, X509::FORMAT_DER);
     }
 
     /**


### PR DESCRIPTION
pour la banque populaire, il est nécessaire de NE PAS envoyer les headers et footer  -----BEGIN/END CERTIFICATE-----

l'option X509::FORMAT_DER a été choisie pour générer le certificat.