### PR TITLE
Migrate phpseclib/phpseclib from ^2.x to ^3.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ kill:
 	docker compose rm -f -s
 
 login:
-	docker compose exec php sh
+	docker compose exec php bash
 
 php:
 	$(BASE) $(COMMAND_ARGS)
@@ -71,7 +71,7 @@ infection: dup
 # Analyse
 
 phpstan:
-	$(BASE) php -d memory_limit=1700M vendor/bin/phpstan analyse --memory-limit 1700M $(COMMAND_ARGS)
+	$(BASE) php -d memory_limit=1700M ./vendor/bin/phpstan analyse --memory-limit 1700M $(COMMAND_ARGS)
 
 phpstan-baseline: dup
 	$(BASE) vendor/bin/phpstan analyse --memory-limit 1000M --generate-baseline $(COMMAND_ARGS)

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "ext-zlib": "*",
     "ext-json": "*",
 
-    "phpseclib/phpseclib": "^2.0.48",
+    "phpseclib/phpseclib": "^3",
     "symfony/http-client": "^6.3.12 || ^7.1.11"
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
-services :
+services:
   php:
-    image: cube43/docker-apache2-php:8.4
+    image: php:8.3.29-fpm
     working_dir: /var/www/
     volumes:
       - .:/var/www

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,86 +1,57 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Strict comparison using \=\=\= between string and false will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: src/BankCertificate.php
-
-		-
-			message: '#^Method Cube43\\Component\\Ebics\\Crypt\\AddRsaSha256PrefixAndReturnAsBinary\:\:unpack\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Cube43\\\\Component\\\\Ebics\\\\Crypt\\\\AddRsaSha256PrefixAndReturnAsBinary\\:\\:unpack\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Crypt/AddRsaSha256PrefixAndReturnAsBinary.php
 
 		-
-			message: '#^Strict comparison using \=\=\= between string and false will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
+			message: "#^Strict comparison using \\=\\=\\= between string and false will always evaluate to false\\.$#"
 			count: 1
 			path: src/Crypt/AddRsaSha256PrefixAndReturnAsBinary.php
 
 		-
-			message: '#^Call to function assert\(\) with true will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
+			message: "#^Cannot call method appendChild\\(\\) on DOMNode\\|null\\.$#"
 			count: 1
 			path: src/Crypt/SignQuery.php
 
 		-
-			message: '#^Cannot call method appendChild\(\) on DOMNode\|null\.$#'
-			identifier: method.nonObject
+			message: "#^Cannot call method insertBefore\\(\\) on DOMNode\\|null\\.$#"
 			count: 1
 			path: src/Crypt/SignQuery.php
 
 		-
-			message: '#^Cannot call method insertBefore\(\) on DOMNode\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Crypt/SignQuery.php
-
-		-
-			message: '#^Instanceof between DOMNode and DOMNode will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
-			count: 1
-			path: src/Crypt/SignQuery.php
-
-		-
-			message: '#^Method Cube43\\Component\\Ebics\\KeyRing\:\:jsonDecode\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: "#^Method Cube43\\\\Component\\\\Ebics\\\\KeyRing\\:\\:jsonDecode\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/KeyRing.php
 
 		-
-			message: '#^Strict comparison using \=\=\= between string and false will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
+			message: "#^Strict comparison using \\=\\=\\= between string and false will always evaluate to false\\.$#"
 			count: 1
 			path: src/UserCertificate.php
 
 		-
-			message: '#^Possibly impure instantiation of class DateTimeImmutable in pure method Cube43\\Component\\Ebics\\X509\\DefaultX509OptionGenerator\:\:getEnd\(\)\.$#'
-			identifier: possiblyImpure.new
-			count: 1
-			path: src/X509/DefaultX509OptionGenerator.php
-
-		-
-			message: '#^Possibly impure instantiation of class DateTimeImmutable in pure method Cube43\\Component\\Ebics\\X509\\DefaultX509OptionGenerator\:\:getStart\(\)\.$#'
-			identifier: possiblyImpure.new
-			count: 1
-			path: src/X509/DefaultX509OptionGenerator.php
-
-		-
-			message: '#^Call to function assert\(\) with true will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: tests/E2e/Command/E2eTestBase.php
-
-		-
-			message: '#^Instanceof between DOMNode and DOMNode will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
-			count: 1
-			path: tests/E2e/Command/E2eTestBase.php
-
-		-
-			message: '#^Parameter \#2 \$digestValue of closure expects string, string\|null given\.$#'
-			identifier: argument.type
+			message: "#^Parameter \\#2 \\$digestValue of closure expects string, string\\|null given\\.$#"
 			count: 2
 			path: tests/E2e/Command/E2eTestBase.php
+
+		-
+			message: "#^Attribute class PHPUnit\\\\Framework\\\\Attributes\\\\DataProvider does not exist\\.$#"
+			count: 1
+			path: tests/E2e/Command/FDLCommandTest.php
+
+		-
+			message: "#^Attribute class PHPUnit\\\\Framework\\\\Attributes\\\\DataProvider does not exist\\.$#"
+			count: 1
+			path: tests/E2e/Command/HIACommandTest.php
+
+		-
+			message: "#^Attribute class PHPUnit\\\\Framework\\\\Attributes\\\\DataProvider does not exist\\.$#"
+			count: 1
+			path: tests/E2e/Command/HPBCommandTest.php
+
+		-
+			message: "#^Attribute class PHPUnit\\\\Framework\\\\Attributes\\\\DataProvider does not exist\\.$#"
+			count: 1
+			path: tests/E2e/Command/INICommandTest.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,5 +5,3 @@ parameters:
         - src
         - bin
         - tests
-includes:
-    - phpstan-baseline.neon

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11,14 +11,6 @@
       <code><![CDATA[public function jsonSerialize(): array]]></code>
     </MissingOverrideAttribute>
   </file>
-  <file src="src/Crypt/SignQuery.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[$domNode]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[DOMNode]]></code>
-    </InvalidReturnType>
-  </file>
   <file src="src/DOMDocument.php">
     <InvalidClass>
       <code><![CDATA[\DOMXpath]]></code>
@@ -40,10 +32,6 @@
     </MissingOverrideAttribute>
   </file>
   <file src="src/X509/DefaultX509OptionGenerator.php">
-    <ImpureMethodCall>
-      <code><![CDATA[new DateTimeImmutable()]]></code>
-      <code><![CDATA[new DateTimeImmutable()]]></code>
-    </ImpureMethodCall>
     <MissingOverrideAttribute>
       <code><![CDATA[public function getEnd(): DateTimeImmutable]]></code>
       <code><![CDATA[public function getFormat(): EbicsX509FormatEnum]]></code>

--- a/src/BankCertificate.php
+++ b/src/BankCertificate.php
@@ -7,7 +7,7 @@ namespace Cube43\Component\Ebics;
 use Cube43\Component\Ebics\Crypt\ExponentAndModulus;
 use ErrorException;
 use JsonSerializable;
-use phpseclib\Crypt\RSA;
+use phpseclib3\Crypt\RSA;
 
 use function assert;
 use function base64_decode;
@@ -35,8 +35,7 @@ class BankCertificate implements JsonSerializable
 
     private static function base64Decode(string $string): string
     {
-        $safeResult = base64_decode($string);
-        assert(is_string($safeResult) || $safeResult === false);
+        $safeResult = base64_decode($string, true);
         if ($safeResult === false) {
             throw new ErrorException('An error occured');
         }
@@ -61,10 +60,7 @@ class BankCertificate implements JsonSerializable
 
     public function getPublicKeyDetails(): ExponentAndModulus
     {
-        $rsa = new RSA();
-        $rsa->setPublicKey($this->publicKey);
-
-        return new ExponentAndModulus($rsa);
+        return new ExponentAndModulus(RSA::loadPublicKey($this->publicKey));
     }
 
     /** @return array<string, string> */

--- a/src/BankCertificate.php
+++ b/src/BankCertificate.php
@@ -9,8 +9,10 @@ use ErrorException;
 use JsonSerializable;
 use phpseclib\Crypt\RSA;
 
+use function assert;
 use function base64_decode;
 use function base64_encode;
+use function is_string;
 
 class BankCertificate implements JsonSerializable
 {
@@ -34,6 +36,7 @@ class BankCertificate implements JsonSerializable
     private static function base64Decode(string $string): string
     {
         $safeResult = base64_decode($string);
+        assert(is_string($safeResult) || $safeResult === false);
         if ($safeResult === false) {
             throw new ErrorException('An error occured');
         }

--- a/src/BankCertificate.php
+++ b/src/BankCertificate.php
@@ -8,7 +8,9 @@ use Cube43\Component\Ebics\Crypt\ExponentAndModulus;
 use ErrorException;
 use JsonSerializable;
 use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\RSA\PublicKey;
 
+use function assert;
 use function base64_decode;
 use function base64_encode;
 
@@ -58,8 +60,8 @@ class BankCertificate implements JsonSerializable
 
     public function getPublicKeyDetails(): ExponentAndModulus
     {
-        /** @var \phpseclib3\Crypt\RSA\PublicKey $key */
         $key = RSA::load($this->publicKey);
+        assert($key instanceof PublicKey);
 
         return new ExponentAndModulus($key);
     }

--- a/src/BankCertificate.php
+++ b/src/BankCertificate.php
@@ -9,10 +9,8 @@ use ErrorException;
 use JsonSerializable;
 use phpseclib3\Crypt\RSA;
 
-use function assert;
 use function base64_decode;
 use function base64_encode;
-use function is_string;
 
 class BankCertificate implements JsonSerializable
 {

--- a/src/BankCertificate.php
+++ b/src/BankCertificate.php
@@ -58,7 +58,10 @@ class BankCertificate implements JsonSerializable
 
     public function getPublicKeyDetails(): ExponentAndModulus
     {
-        return new ExponentAndModulus(RSA::loadPublicKey($this->publicKey));
+        /** @var \phpseclib3\Crypt\RSA\PublicKey $key */
+        $key = RSA::load($this->publicKey);
+
+        return new ExponentAndModulus($key);
     }
 
     /** @return array<string, string> */

--- a/src/CertificateX509.php
+++ b/src/CertificateX509.php
@@ -36,7 +36,12 @@ class CertificateX509
         $this->x509 = new X509();
 
         if ($this->isHexadecimal($value)) {
-            $this->x509->loadX509(hex2bin($value));
+            $value2Bin = hex2bin($value);
+            if ($value2Bin === false) {
+                throw new RuntimeException('x509 value is not DER format');
+            }
+
+            $this->x509->loadX509($value2Bin);
         } else {
             $this->x509->loadX509($value);
         }
@@ -95,6 +100,7 @@ class CertificateX509
         return $certificateSerialNumber->toString();
     }
 
+    /** @return mixed[] */
     public function getCurrentCert(): array
     {
         return $this->x509->currentCert;

--- a/src/CertificateX509.php
+++ b/src/CertificateX509.php
@@ -80,9 +80,7 @@ class CertificateX509
         return implode("\n", $digests);
     }
 
-    /**
-     * @deprecated Use always fingerprint method
-     */
+    /** @deprecated Use always fingerprint method */
     public function digest(): string
     {
         $digest  = strtoupper(hash('sha256', $this->value, false));

--- a/src/CertificateX509.php
+++ b/src/CertificateX509.php
@@ -7,16 +7,18 @@ namespace Cube43\Component\Ebics;
 use ErrorException;
 use phpseclib\File\X509;
 use RuntimeException;
-use Throwable;
 
 use function array_map;
 use function array_shift;
 use function base64_encode;
 use function chunk_split;
 use function hash;
+use function hex2bin;
 use function implode;
 use function is_array;
 use function openssl_x509_fingerprint;
+use function preg_match;
+use function str_contains;
 use function str_split;
 use function strtoupper;
 use function wordwrap;
@@ -25,14 +27,25 @@ class CertificateX509
 {
     private readonly X509 $x509;
 
-    public function __construct(private string $value)
+    public function __construct(private readonly string $value)
     {
         if (empty($value)) {
             throw new RuntimeException('x509 key is empty');
         }
 
         $this->x509 = new X509();
-        $this->x509->loadX509($value);
+
+        if ($this->isHexadecimal($value)) {
+            $this->x509->loadX509(hex2bin($value));
+        } else {
+            $this->x509->loadX509($value);
+        }
+    }
+
+    private function isHexadecimal(string $str): bool
+    {
+        // Autoriser uniquement 0-9, a-f, A-F, espaces et ":"
+        return (bool) preg_match('/^[0-9a-fA-F:\s]+$/', $str);
     }
 
     public function value(): string
@@ -42,12 +55,15 @@ class CertificateX509
 
     public function fingerprint(): string
     {
-        try {
-            $digest = strtoupper(self::opensslX509Fingerprint($this->value, 'sha256'));
-        } catch (Throwable) {
-            $under  = "-----BEGIN CERTIFICATE-----\r\n" . chunk_split(base64_encode($this->value), 64) . '-----END CERTIFICATE-----';
-            $digest = strtoupper(self::opensslX509Fingerprint($under, 'sha256'));
+        $contentCert = $this->value;
+        // Si pas BEGIN CERTIFICATE alors c'est un encodage DER, il faut le transformer en PEM
+        if (! str_contains($contentCert, '-----BEGIN CERTIFICATE-----')) {
+            $contentCert = "-----BEGIN CERTIFICATE-----\n"
+                . chunk_split(base64_encode($contentCert), 64, "\n")
+                . "-----END CERTIFICATE-----\n";
         }
+
+        $digest = strtoupper(self::opensslX509Fingerprint($contentCert, 'sha256'));
 
         $digests = str_split($digest, 16);
         $digests = array_map(static function ($digest) {
@@ -57,6 +73,9 @@ class CertificateX509
         return implode("\n", $digests);
     }
 
+    /**
+     * @deprecated Use always fingerprint method
+     */
     public function digest(): string
     {
         $digest  = strtoupper(hash('sha256', $this->value, false));
@@ -74,6 +93,11 @@ class CertificateX509
         $certificateSerialNumber = $this->x509->currentCert['tbsCertificate']['serialNumber'];
 
         return $certificateSerialNumber->toString();
+    }
+
+    public function getCurrentCert(): array
+    {
+        return $this->x509->currentCert;
     }
 
     /** @internal */

--- a/src/CertificateX509.php
+++ b/src/CertificateX509.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Cube43\Component\Ebics;
 
 use ErrorException;
-use phpseclib\File\X509;
+use phpseclib3\File\X509;
 use RuntimeException;
 
 use function array_map;
@@ -26,6 +26,8 @@ use function wordwrap;
 class CertificateX509
 {
     private readonly X509 $x509;
+    /** @var array<mixed>|false */
+    private readonly array|false $parsedCert;
 
     public function __construct(private readonly string $value)
     {
@@ -41,9 +43,9 @@ class CertificateX509
                 throw new RuntimeException('x509 value is not DER format');
             }
 
-            $this->x509->loadX509($value2Bin);
+            $this->parsedCert = $this->x509->loadX509($value2Bin);
         } else {
-            $this->x509->loadX509($value);
+            $this->parsedCert = $this->x509->loadX509($value);
         }
     }
 
@@ -95,15 +97,17 @@ class CertificateX509
     /** @internal */
     public function getSerialNumber(): string
     {
-        $certificateSerialNumber = $this->x509->currentCert['tbsCertificate']['serialNumber'];
+        if ($this->parsedCert === false || ! isset($this->parsedCert['tbsCertificate']['serialNumber'])) {
+            throw new RuntimeException('Unable to get serial number from certificate');
+        }
 
-        return $certificateSerialNumber->toString();
+        return $this->parsedCert['tbsCertificate']['serialNumber']->toString();
     }
 
     /** @return mixed[] */
     public function getCurrentCert(): array
     {
-        return $this->x509->currentCert;
+        return $this->parsedCert ?: [];
     }
 
     /** @internal */

--- a/src/Command/FDLCommand.php
+++ b/src/Command/FDLCommand.php
@@ -21,6 +21,7 @@ use RuntimeException;
 use function base64_decode;
 use function bin2hex;
 use function in_array;
+use function random_bytes;
 use function strtoupper;
 
 class FDLCommand

--- a/src/Command/FDLCommand.php
+++ b/src/Command/FDLCommand.php
@@ -16,7 +16,6 @@ use Cube43\Component\Ebics\OrderDataEncrypted;
 use Cube43\Component\Ebics\RenderXml;
 use Cube43\Component\Ebics\SymfonyEbicsServerCaller;
 use DateTime;
-use phpseclib\Crypt\Random;
 use RuntimeException;
 
 use function base64_decode;
@@ -86,7 +85,7 @@ class FDLCommand
         $search = [
             '{{DateRange}}' => $dateRange === '' ? '' : '<DateRange>' . $dateRange . '</DateRange>',
             '{{HostID}}' => $bank->getHostId(),
-            '{{Nonce}}' => strtoupper(bin2hex(Random::string(16))),
+            '{{Nonce}}' => strtoupper(bin2hex(random_bytes(16))),
             '{{Timestamp}}' => (new DateTime())->format('Y-m-d\TH:i:s\Z'),
             '{{PartnerID}}' => $bank->getPartnerId(),
             '{{UserID}}' => $bank->getUserId(),

--- a/src/Command/HPBCommand.php
+++ b/src/Command/HPBCommand.php
@@ -17,9 +17,8 @@ use Cube43\Component\Ebics\OrderDataEncrypted;
 use Cube43\Component\Ebics\RenderXml;
 use Cube43\Component\Ebics\SymfonyEbicsServerCaller;
 use DateTime;
-use phpseclib\Crypt\Random;
-use phpseclib\Crypt\RSA;
-use phpseclib\Math\BigInteger;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Math\BigInteger;
 
 use function base64_decode;
 use function bin2hex;
@@ -47,7 +46,7 @@ class HPBCommand
     {
         $search = [
             '{{HostID}}' => $bank->getHostId(),
-            '{{Nonce}}' => strtoupper(bin2hex(Random::string(16))),
+            '{{Nonce}}' => strtoupper(bin2hex(random_bytes(16))),
             '{{Timestamp}}' => (new DateTime())->format('Y-m-d\TH:i:s\Z'),
             '{{PartnerID}}' => $bank->getPartnerId(),
             '{{UserID}}' => $bank->getUserId(),
@@ -81,15 +80,15 @@ class HPBCommand
 
     private function cert(DOMDocument $decrypted, CertificatType $certificatType, string $parentNode): BankCertificate
     {
-        $rsa = new RSA();
-        $rsa->loadKey([
+        // @phpstan-ignore-next-line — phpseclib3 accepts array components but its PHPDoc only declares string
+        $publicKey = RSA::load([
             'n' => new BigInteger(base64_decode($decrypted->getNodeValueChildOf('Modulus', $parentNode)), 256),
             'e' => new BigInteger(base64_decode($decrypted->getNodeValueChildOf('Exponent', $parentNode)), 256),
         ]);
 
         return new BankCertificate(
             $certificatType,
-            $rsa->getPublicKey(RSA::PUBLIC_FORMAT_PKCS1),
+            $publicKey->toString('PKCS1'),
             new CertificateX509(bin2hex(base64_decode($decrypted->getNodeValueChildOf('X509Certificate', $parentNode)))),
         );
     }

--- a/src/Command/HPBCommand.php
+++ b/src/Command/HPBCommand.php
@@ -81,7 +81,8 @@ class HPBCommand
 
     private function cert(DOMDocument $decrypted, CertificatType $certificatType, string $parentNode): BankCertificate
     {
-        // @phpstan-ignore-next-line — phpseclib3 accepts array components but its PHPDoc only declares string
+        /** @psalm-suppress InvalidArgument — phpseclib3 accepts array components but its PHPDoc only declares string */
+        // @phpstan-ignore-next-line
         $publicKey = RSA::load([
             'n' => new BigInteger(base64_decode($decrypted->getNodeValueChildOf('Modulus', $parentNode)), 256),
             'e' => new BigInteger(base64_decode($decrypted->getNodeValueChildOf('Exponent', $parentNode)), 256),

--- a/src/Command/HPBCommand.php
+++ b/src/Command/HPBCommand.php
@@ -22,6 +22,7 @@ use phpseclib3\Math\BigInteger;
 
 use function base64_decode;
 use function bin2hex;
+use function random_bytes;
 use function strtoupper;
 
 class HPBCommand

--- a/src/Crypt/AddRsaSha256PrefixAndReturnAsBinary.php
+++ b/src/Crypt/AddRsaSha256PrefixAndReturnAsBinary.php
@@ -19,6 +19,7 @@ class AddRsaSha256PrefixAndReturnAsBinary
         return self::pack('c*', ...self::RSA_SHA256_PREFIX, ...self::unpack('C*', $hash));
     }
 
+    /** @return array<int, int> */
     private static function unpack(string $format, string $string): array
     {
         $safeResult = unpack($format, $string);
@@ -32,6 +33,7 @@ class AddRsaSha256PrefixAndReturnAsBinary
     private static function pack(string $string, mixed ...$values): string
     {
         $safeResult = pack($string, ...$values);
+        // @phpstan-ignore identical.alwaysFalse
         if ($safeResult === false) {
             throw new ErrorException('An error occured');
         }

--- a/src/Crypt/BankPublicKeyDigest.php
+++ b/src/Crypt/BankPublicKeyDigest.php
@@ -19,7 +19,8 @@ class BankPublicKeyDigest
 {
     public function __invoke(BankCertificate $certificate): string
     {
-        $publicKey = RSA::loadPublicKey($certificate->getPublicKey());
+        /** @var \phpseclib3\Crypt\RSA\PublicKey $publicKey */
+        $publicKey = RSA::load($certificate->getPublicKey());
 
         return base64_encode(hash('sha256', $this->generateDigest($publicKey), true));
     }

--- a/src/Crypt/BankPublicKeyDigest.php
+++ b/src/Crypt/BankPublicKeyDigest.php
@@ -7,7 +7,7 @@ namespace Cube43\Component\Ebics\Crypt;
 use Cube43\Component\Ebics\BankCertificate;
 use phpseclib3\Crypt\Common\PublicKey;
 use phpseclib3\Crypt\RSA;
-use RuntimeException;
+use phpseclib3\Math\BigInteger;
 
 use function base64_encode;
 use function hash;
@@ -26,7 +26,7 @@ class BankPublicKeyDigest
 
     private function generateDigest(PublicKey $publicKey): string
     {
-        /** @var array{e: \phpseclib3\Math\BigInteger, n: \phpseclib3\Math\BigInteger} */
+        /** @var array{e: BigInteger, n: BigInteger} $raw */
         $raw      = $publicKey->toString('Raw');
         $exponent = $raw['e']->toHex();
         $modulus  = $raw['n']->toHex();

--- a/src/Crypt/BankPublicKeyDigest.php
+++ b/src/Crypt/BankPublicKeyDigest.php
@@ -9,6 +9,7 @@ use phpseclib3\Crypt\Common\PublicKey;
 use phpseclib3\Crypt\RSA;
 use phpseclib3\Math\BigInteger;
 
+use function assert;
 use function base64_encode;
 use function hash;
 use function ltrim;
@@ -19,8 +20,8 @@ class BankPublicKeyDigest
 {
     public function __invoke(BankCertificate $certificate): string
     {
-        /** @var \phpseclib3\Crypt\RSA\PublicKey $publicKey */
         $publicKey = RSA::load($certificate->getPublicKey());
+        assert($publicKey instanceof \phpseclib3\Crypt\RSA\PublicKey);
 
         return base64_encode(hash('sha256', $this->generateDigest($publicKey), true));
     }

--- a/src/Crypt/BankPublicKeyDigest.php
+++ b/src/Crypt/BankPublicKeyDigest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Cube43\Component\Ebics\Crypt;
 
 use Cube43\Component\Ebics\BankCertificate;
-use phpseclib\Crypt\RSA;
+use phpseclib3\Crypt\Common\PublicKey;
+use phpseclib3\Crypt\RSA;
 use RuntimeException;
 
 use function base64_encode;
@@ -18,19 +19,17 @@ class BankPublicKeyDigest
 {
     public function __invoke(BankCertificate $certificate): string
     {
-        $publicKey = new RSA();
-
-        if ($publicKey->loadKey($certificate->getPublicKey()) === false) {
-            throw new RuntimeException('unable to load key');
-        }
+        $publicKey = RSA::loadPublicKey($certificate->getPublicKey());
 
         return base64_encode(hash('sha256', $this->generateDigest($publicKey), true));
     }
 
-    private function generateDigest(RSA $publicKey): string
+    private function generateDigest(PublicKey $publicKey): string
     {
-        $exponent = $publicKey->exponent->toHex(true);
-        $modulus  = $publicKey->modulus->toHex(true);
+        /** @var array{e: \phpseclib3\Math\BigInteger, n: \phpseclib3\Math\BigInteger} */
+        $raw      = $publicKey->toString('Raw');
+        $exponent = $raw['e']->toHex();
+        $modulus  = $raw['n']->toHex();
 
         // If key was formed incorrect with Modulus and Exponent mismatch, then change the place of key parts.
         if (strlen($exponent) > strlen($modulus)) {

--- a/src/Crypt/DecryptOrderDataContent.php
+++ b/src/Crypt/DecryptOrderDataContent.php
@@ -22,11 +22,11 @@ class DecryptOrderDataContent
 {
     public function __invoke(KeyRing $keyRing, OrderDataEncrypted $orderData): string
     {
-        $rsa = RSA::loadPrivateKey(
+        /** @var RsaPrivateKey $rsa */
+        $rsa = RSA::load(
             $keyRing->getUserCertificateE()->getPrivateKey()->value(),
             $keyRing->getPassword(),
         );
-        assert($rsa instanceof RsaPrivateKey);
         $rsa = $rsa->withPadding(RSA::ENCRYPTION_PKCS1);
 
         $transactionKeyDecrypted = $rsa->decrypt($orderData->getTransactionKey());

--- a/src/Crypt/DecryptOrderDataContent.php
+++ b/src/Crypt/DecryptOrderDataContent.php
@@ -12,18 +12,21 @@ use phpseclib3\Crypt\RSA;
 use phpseclib3\Crypt\RSA\PrivateKey as RsaPrivateKey;
 use RuntimeException;
 
+use function assert;
+use function base64_decode;
 use function gzuncompress;
+use function str_repeat;
 
 /** @internal */
 class DecryptOrderDataContent
 {
     public function __invoke(KeyRing $keyRing, OrderDataEncrypted $orderData): string
     {
-        /** @var RsaPrivateKey $rsa */
         $rsa = RSA::loadPrivateKey(
             $keyRing->getUserCertificateE()->getPrivateKey()->value(),
             $keyRing->getPassword(),
         );
+        assert($rsa instanceof RsaPrivateKey);
         $rsa = $rsa->withPadding(RSA::ENCRYPTION_PKCS1);
 
         $transactionKeyDecrypted = $rsa->decrypt($orderData->getTransactionKey());

--- a/src/Crypt/DecryptOrderDataContent.php
+++ b/src/Crypt/DecryptOrderDataContent.php
@@ -22,11 +22,11 @@ class DecryptOrderDataContent
 {
     public function __invoke(KeyRing $keyRing, OrderDataEncrypted $orderData): string
     {
-        /** @var RsaPrivateKey $rsa */
         $rsa = RSA::load(
             $keyRing->getUserCertificateE()->getPrivateKey()->value(),
             $keyRing->getPassword(),
         );
+        assert($rsa instanceof RsaPrivateKey);
         $rsa = $rsa->withPadding(RSA::ENCRYPTION_PKCS1);
 
         $transactionKeyDecrypted = $rsa->decrypt($orderData->getTransactionKey());

--- a/src/Crypt/DecryptOrderDataContent.php
+++ b/src/Crypt/DecryptOrderDataContent.php
@@ -7,36 +7,34 @@ namespace Cube43\Component\Ebics\Crypt;
 use Cube43\Component\Ebics\KeyRing;
 use Cube43\Component\Ebics\OrderDataEncrypted;
 use ErrorException;
-use phpseclib\Crypt\AES;
-use phpseclib\Crypt\RSA;
+use phpseclib3\Crypt\AES;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\RSA\PrivateKey as RsaPrivateKey;
 use RuntimeException;
 
 use function gzuncompress;
-
-use const OPENSSL_ZERO_PADDING;
 
 /** @internal */
 class DecryptOrderDataContent
 {
     public function __invoke(KeyRing $keyRing, OrderDataEncrypted $orderData): string
     {
-        $rsa = new RSA();
-        $rsa->setPassword($keyRing->getPassword());
-        $rsa->loadKey($keyRing->getUserCertificateE()->getPrivateKey()->value());
-        $rsa->setEncryptionMode(RSA::ENCRYPTION_PKCS1);
+        /** @var RsaPrivateKey $rsa */
+        $rsa = RSA::loadPrivateKey(
+            $keyRing->getUserCertificateE()->getPrivateKey()->value(),
+            $keyRing->getPassword(),
+        );
+        $rsa = $rsa->withPadding(RSA::ENCRYPTION_PKCS1);
 
         $transactionKeyDecrypted = $rsa->decrypt($orderData->getTransactionKey());
 
-        // aes-128-cbc encrypting format.
-        $aes = new AES(AES::MODE_CBC);
+        $aes = new AES('cbc');
         $aes->setKeyLength(128);
         $aes->setKey($transactionKeyDecrypted);
+        $aes->setIV(str_repeat("\0", 16));
+        $aes->disablePadding();
 
-        // Force openssl_options.
-        // phpcs:ignore
-        $aes->openssl_options = OPENSSL_ZERO_PADDING;
-
-        $decrypted = $aes->decrypt($orderData->getOrderData());
+        $decrypted = $aes->decrypt(base64_decode($orderData->getOrderData()));
 
         if (empty($decrypted)) {
             throw new RuntimeException('decrypt error');

--- a/src/Crypt/EncrytSignatureValueWithUserPrivateKey.php
+++ b/src/Crypt/EncrytSignatureValueWithUserPrivateKey.php
@@ -6,11 +6,12 @@ namespace Cube43\Component\Ebics\Crypt;
 
 use Cube43\Component\Ebics\KeyRing;
 use Cube43\Component\Ebics\PrivateKey;
-use phpseclib\Crypt\RSA;
 use RuntimeException;
 
-use function define;
-use function defined;
+use function openssl_pkey_get_private;
+use function openssl_private_encrypt;
+
+use const OPENSSL_PKCS1_PADDING;
 
 /** @internal */
 class EncrytSignatureValueWithUserPrivateKey
@@ -25,18 +26,16 @@ class EncrytSignatureValueWithUserPrivateKey
     /** @throws RuntimeException */
     public function __invoke(KeyRing $keyRing, PrivateKey $key, string $hash): string
     {
-        $rsa = new RSA();
-        $rsa->setPassword($keyRing->getPassword());
-        $rsa->loadKey($key->value(), RSA::PRIVATE_FORMAT_PKCS1);
+        $password       = $keyRing->getPassword();
+        $privateKeyRes  = openssl_pkey_get_private($key->value(), $password !== '' ? $password : null);
 
-        if (! defined('CRYPT_RSA_PKCS15_COMPAT')) {
-            define('CRYPT_RSA_PKCS15_COMPAT', true);
+        if ($privateKeyRes === false) {
+            throw new RuntimeException('Unable to load private key.');
         }
 
-        $rsa->setEncryptionMode(RSA::ENCRYPTION_PKCS1);
-        $encrypted = $rsa->encrypt($this->addRsaSha256PrefixAndReturnAsBinary->__invoke($hash));
+        $formattedData = $this->addRsaSha256PrefixAndReturnAsBinary->__invoke($hash);
 
-        if (empty($encrypted)) {
+        if (openssl_private_encrypt($formattedData, $encrypted, $privateKeyRes, OPENSSL_PKCS1_PADDING) === false) {
             throw new RuntimeException('Incorrect authorization.');
         }
 

--- a/src/Crypt/EncrytSignatureValueWithUserPrivateKey.php
+++ b/src/Crypt/EncrytSignatureValueWithUserPrivateKey.php
@@ -26,8 +26,8 @@ class EncrytSignatureValueWithUserPrivateKey
     /** @throws RuntimeException */
     public function __invoke(KeyRing $keyRing, PrivateKey $key, string $hash): string
     {
-        $password       = $keyRing->getPassword();
-        $privateKeyRes  = openssl_pkey_get_private($key->value(), $password !== '' ? $password : null);
+        $password      = $keyRing->getPassword();
+        $privateKeyRes = openssl_pkey_get_private($key->value(), $password !== '' ? $password : null);
 
         if ($privateKeyRes === false) {
             throw new RuntimeException('Unable to load private key.');

--- a/src/Crypt/EncrytSignatureValueWithUserPrivateKey.php
+++ b/src/Crypt/EncrytSignatureValueWithUserPrivateKey.php
@@ -27,7 +27,7 @@ class EncrytSignatureValueWithUserPrivateKey
     public function __invoke(KeyRing $keyRing, PrivateKey $key, string $hash): string
     {
         $password      = $keyRing->getPassword();
-        $privateKeyRes = openssl_pkey_get_private($key->value(), $password !== '' ? $password : null);
+        $privateKeyRes = openssl_pkey_get_private($key->value(), $password);
 
         if ($privateKeyRes === false) {
             throw new RuntimeException('Unable to load private key.');

--- a/src/Crypt/ExponentAndModulus.php
+++ b/src/Crypt/ExponentAndModulus.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Cube43\Component\Ebics\Crypt;
 
 use phpseclib3\Crypt\Common\PublicKey;
+use phpseclib3\Math\BigInteger;
 
 /** @internal */
 class ExponentAndModulus
 {
-    /** @var array{e: \phpseclib3\Math\BigInteger, n: \phpseclib3\Math\BigInteger} */
+    /** @var array{e: BigInteger, n: BigInteger} */
     private readonly array $components;
 
     public function __construct(PublicKey $key)
     {
-        /** @var array{e: \phpseclib3\Math\BigInteger, n: \phpseclib3\Math\BigInteger} $components */
+        /** @var array{e: BigInteger, n: BigInteger} $components */
         $components       = $key->toString('Raw');
         $this->components = $components;
     }

--- a/src/Crypt/ExponentAndModulus.php
+++ b/src/Crypt/ExponentAndModulus.php
@@ -4,22 +4,28 @@ declare(strict_types=1);
 
 namespace Cube43\Component\Ebics\Crypt;
 
-use phpseclib\Crypt\RSA;
+use phpseclib3\Crypt\Common\PublicKey;
 
 /** @internal */
 class ExponentAndModulus
 {
-    public function __construct(private readonly RSA $rsa)
+    /** @var array{e: \phpseclib3\Math\BigInteger, n: \phpseclib3\Math\BigInteger} */
+    private readonly array $components;
+
+    public function __construct(PublicKey $key)
     {
+        /** @var array{e: \phpseclib3\Math\BigInteger, n: \phpseclib3\Math\BigInteger} $components */
+        $components       = $key->toString('Raw');
+        $this->components = $components;
     }
 
     public function getExponent(): string
     {
-        return $this->rsa->exponent->toBytes();
+        return $this->components['e']->toBytes();
     }
 
     public function getModulus(): string
     {
-        return $this->rsa->modulus->toBytes();
+        return $this->components['n']->toBytes();
     }
 }

--- a/src/Crypt/GenerateCertificat.php
+++ b/src/Crypt/GenerateCertificat.php
@@ -11,11 +11,7 @@ use Cube43\Component\Ebics\PrivateKey;
 use Cube43\Component\Ebics\UserCertificate;
 use Cube43\Component\Ebics\X509\X509CertificatOptionsGenerator;
 use Cube43\Component\Ebics\X509\X509Generator;
-use phpseclib\Crypt\RSA;
-use RuntimeException;
-
-use function array_key_exists;
-use function sprintf;
+use phpseclib3\Crypt\RSA;
 
 /** @internal */
 class GenerateCertificat
@@ -29,38 +25,16 @@ class GenerateCertificat
 
     public function __invoke(X509CertificatOptionsGenerator $x509CertificatOptionsGenerator, KeyRing $keyring, CertificatType $type): UserCertificate
     {
-        $rsa = new RSA();
-        $rsa->setPublicKeyFormat(RSA::PRIVATE_FORMAT_PKCS1);
-        $rsa->setPrivateKeyFormat(RSA::PUBLIC_FORMAT_PKCS1);
-        $rsa->setHash('sha256');
-        $rsa->setMGFHash('sha256');
-        $rsa->setPassword($keyring->getPassword());
+        $privateKey = RSA::createKey(2048);
+        $publicKey  = $privateKey->getPublicKey();
 
-        $keys = $rsa->createKey(2048);
-
-        if (empty($keys)) {
-            throw new RuntimeException(sprintf('key "publickey" does not exist for certificat type "%s"', $type->value()));
-        }
-
-        if (! array_key_exists('publickey', $keys) || empty($keys['publickey'])) {
-            throw new RuntimeException(sprintf('key "publickey" does not exist for certificat type "%s"', $type->value()));
-        }
-
-        if (! array_key_exists('privatekey', $keys) || empty($keys['privatekey'])) {
-            throw new RuntimeException(sprintf('key "privatekey" does not exist for certificat type "%s"', $type->value()));
-        }
-
-        $privateKey = new RSA();
-        $privateKey->loadKey($keys['privatekey']);
-
-        $publicKey = new RSA();
-        $publicKey->loadKey($keys['publickey']);
-        $publicKey->setPublicKey();
+        $privateKeyString = $privateKey->withPassword($keyring->getPassword())->toString('PKCS1');
+        $publicKeyString  = $publicKey->toString('PKCS1');
 
         return new UserCertificate(
             $type,
-            $keys['publickey'],
-            new PrivateKey($keys['privatekey']),
+            $publicKeyString,
+            new PrivateKey($privateKeyString),
             new CertificateX509($this->x509Generator->__invoke($privateKey, $publicKey, $type, $x509CertificatOptionsGenerator)),
         );
     }

--- a/src/Crypt/SignQuery.php
+++ b/src/Crypt/SignQuery.php
@@ -128,11 +128,16 @@ class SignQuery
 
     protected function insertAfter(DOMNode $newNode, DOMNode $afterNode): void
     {
+        $parent = $afterNode->parentNode;
+        if ($parent === null) {
+            return;
+        }
+
         $nextSibling = $afterNode->nextSibling;
         if ($newNode !== $nextSibling) {
-            $afterNode->parentNode->insertBefore($newNode, $nextSibling);
+            $parent->insertBefore($newNode, $nextSibling);
         } else {
-            $afterNode->parentNode->appendChild($newNode);
+            $parent->appendChild($newNode);
         }
     }
 
@@ -147,6 +152,10 @@ class SignQuery
         $domNode = $domNodeList->item(0);
         if ($domNode === null) {
             throw new RuntimeException(sprintf('Unable to find "%s" in "%s"', $query, $document->toString()));
+        }
+
+        if (! $domNode instanceof DOMNode) {
+            throw new RuntimeException(sprintf('Unexpected node type for "%s"', $query));
         }
 
         return $domNode;

--- a/src/KeyRing.php
+++ b/src/KeyRing.php
@@ -208,6 +208,7 @@ class KeyRing implements JsonSerializable
         ];
     }
 
+    /** @return array<mixed> */
     private static function jsonDecode(string $json, bool $assoc = false): array
     {
         $safeResult = json_decode($json, $assoc);

--- a/src/UserCertificate.php
+++ b/src/UserCertificate.php
@@ -8,7 +8,9 @@ use Cube43\Component\Ebics\Crypt\ExponentAndModulus;
 use ErrorException;
 use JsonSerializable;
 use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\RSA\PublicKey;
 
+use function assert;
 use function base64_decode;
 use function base64_encode;
 
@@ -65,8 +67,8 @@ class UserCertificate implements JsonSerializable
 
     public function getPublicKeyDetails(): ExponentAndModulus
     {
-        /** @var \phpseclib3\Crypt\RSA\PublicKey $key */
         $key = RSA::load($this->publicKey);
+        assert($key instanceof PublicKey);
 
         return new ExponentAndModulus($key);
     }

--- a/src/UserCertificate.php
+++ b/src/UserCertificate.php
@@ -7,7 +7,7 @@ namespace Cube43\Component\Ebics;
 use Cube43\Component\Ebics\Crypt\ExponentAndModulus;
 use ErrorException;
 use JsonSerializable;
-use phpseclib\Crypt\RSA;
+use phpseclib3\Crypt\RSA;
 
 use function base64_decode;
 use function base64_encode;
@@ -35,7 +35,7 @@ class UserCertificate implements JsonSerializable
 
     private static function base64Decode(string $string): string
     {
-        $safeResult = base64_decode($string);
+        $safeResult = base64_decode($string, true);
         if ($safeResult === false) {
             throw new ErrorException('An error occured');
         }
@@ -65,10 +65,7 @@ class UserCertificate implements JsonSerializable
 
     public function getPublicKeyDetails(): ExponentAndModulus
     {
-        $rsa = new RSA();
-        $rsa->setPublicKey($this->publicKey);
-
-        return new ExponentAndModulus($rsa);
+        return new ExponentAndModulus(RSA::loadPublicKey($this->publicKey));
     }
 
     /** @return array<string, string> */

--- a/src/UserCertificate.php
+++ b/src/UserCertificate.php
@@ -65,7 +65,10 @@ class UserCertificate implements JsonSerializable
 
     public function getPublicKeyDetails(): ExponentAndModulus
     {
-        return new ExponentAndModulus(RSA::loadPublicKey($this->publicKey));
+        /** @var \phpseclib3\Crypt\RSA\PublicKey $key */
+        $key = RSA::load($this->publicKey);
+
+        return new ExponentAndModulus($key);
     }
 
     /** @return array<string, string> */

--- a/src/X509/DefaultX509OptionGenerator.php
+++ b/src/X509/DefaultX509OptionGenerator.php
@@ -42,13 +42,11 @@ class DefaultX509OptionGenerator implements X509CertificatOptionsGenerator
         ];
     }
 
-    /** @psalm-pure */
     public function getStart(): DateTimeImmutable
     {
         return (new DateTimeImmutable())->modify('-1 days');
     }
 
-    /** @psalm-pure */
     public function getEnd(): DateTimeImmutable
     {
         return (new DateTimeImmutable())->modify('+1 year');

--- a/src/X509/EbicsX509FormatEnum.php
+++ b/src/X509/EbicsX509FormatEnum.php
@@ -6,6 +6,6 @@ namespace Cube43\Component\Ebics\X509;
 
 enum EbicsX509FormatEnum: string
 {
-    case PEM = 'PEM';
-    case DER = 'DER';
-}
+case PEM = 'PEM';
+case DER = 'DER';
+    }

--- a/src/X509/EbicsX509FormatEnum.php
+++ b/src/X509/EbicsX509FormatEnum.php
@@ -6,6 +6,6 @@ namespace Cube43\Component\Ebics\X509;
 
 enum EbicsX509FormatEnum: string
 {
-case PEM = 'PEM';
-case DER = 'DER';
-    }
+    case PEM = 'PEM';
+    case DER = 'DER';
+}

--- a/src/X509/X509Generator.php
+++ b/src/X509/X509Generator.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Cube43\Component\Ebics\X509;
 
 use Cube43\Component\Ebics\CertificatType;
-use phpseclib\Crypt\RSA;
-use phpseclib\File\X509;
+use phpseclib3\Crypt\RSA\PrivateKey;
+use phpseclib3\Crypt\RSA\PublicKey;
+use phpseclib3\File\X509;
 use RuntimeException;
 
 use function array_merge;
@@ -17,7 +18,7 @@ use function var_export;
 
 class X509Generator
 {
-    public function __invoke(RSA $privateKey, RSA $publicKey, CertificatType $type, X509CertificatOptionsGenerator $certificatOptionsGenerator): string
+    public function __invoke(PrivateKey $privateKey, PublicKey $publicKey, CertificatType $type, X509CertificatOptionsGenerator $certificatOptionsGenerator): string
     {
         $options = array_merge([
             'type' => $type->value(),
@@ -31,12 +32,12 @@ class X509Generator
 
         $subject            = $this->generateSubject($publicKey, $options);
         $issuer             = $this->generateIssuer($privateKey, $publicKey, $subject, $options);
-        $x509               = new X509();
-        $x509->startDate    = $certificatOptionsGenerator->getStart()->format('YmdHis');
-        $x509->endDate      = $certificatOptionsGenerator->getEnd()->format('YmdHis');
-        $x509->serialNumber = $this->generateSerialNumber();
+        $x509 = new X509();
+        $x509->setStartDate($certificatOptionsGenerator->getStart());
+        $x509->setEndDate($certificatOptionsGenerator->getEnd());
+        $x509->setSerialNumber($this->generateSerialNumber(), 10);
 
-        $result = $x509->sign($issuer, $subject, 'sha256WithRSAEncryption');
+        $result = $x509->sign($issuer, $subject);
         $x509->loadX509($result);
 
         foreach ($options['extensions'] as $id => $extension) {
@@ -47,7 +48,7 @@ class X509Generator
             }
         }
 
-        $result = $x509->sign($issuer, $x509, 'sha256WithRSAEncryption');
+        $result = $x509->sign($issuer, $x509);
 
         return $x509->saveX509($result, match ($certificatOptionsGenerator->getFormat()) {
             EbicsX509FormatEnum::PEM => X509::FORMAT_PEM,
@@ -56,10 +57,10 @@ class X509Generator
     }
 
     /** @param array<string, mixed> $options */
-    private function generateSubject(RSA $publicKey, array $options): X509
+    private function generateSubject(PublicKey $publicKey, array $options): X509
     {
         $subject = new X509();
-        $subject->setPublicKey($publicKey); // $pubKey is Crypt_RSA object
+        $subject->setPublicKey($publicKey);
 
         if (! empty($options['subject']['DN'])) {
             $subject->setDN($options['subject']['DN']);
@@ -69,16 +70,16 @@ class X509Generator
             $subject->setDomain($options['subject']['domain']);
         }
 
-        $subject->setKeyIdentifier($subject->computeKeyIdentifier($publicKey)); // id-ce-subjectKeyIdentifier
+        $subject->setKeyIdentifier($subject->computeKeyIdentifier($publicKey->toString('PKCS1')));
 
         return $subject;
     }
 
     /** @param array<string, mixed> $options */
-    private function generateIssuer(RSA $privateKey, RSA $publicKey, X509 $subject, array $options): X509
+    private function generateIssuer(PrivateKey $privateKey, PublicKey $publicKey, X509 $subject, array $options): X509
     {
         $issuer = new X509();
-        $issuer->setPrivateKey($privateKey); // $privKey is Crypt_RSA object
+        $issuer->setPrivateKey($privateKey);
 
         if (! empty($options['issuer']['DN'])) {
             $issuer->setDN($options['issuer']['DN']);
@@ -86,7 +87,7 @@ class X509Generator
             $issuer->setDN($subject->getDN());
         }
 
-        $issuer->setKeyIdentifier($subject->computeKeyIdentifier($publicKey));
+        $issuer->setKeyIdentifier($subject->computeKeyIdentifier($publicKey->toString('PKCS1')));
 
         return $issuer;
     }

--- a/src/X509/X509Generator.php
+++ b/src/X509/X509Generator.php
@@ -30,9 +30,9 @@ class X509Generator
             'extensions' => [],
         ], $certificatOptionsGenerator->getOption());
 
-        $subject            = $this->generateSubject($publicKey, $options);
-        $issuer             = $this->generateIssuer($privateKey, $publicKey, $subject, $options);
-        $x509 = new X509();
+        $subject = $this->generateSubject($publicKey, $options);
+        $issuer  = $this->generateIssuer($privateKey, $publicKey, $subject, $options);
+        $x509    = new X509();
         $x509->setStartDate($certificatOptionsGenerator->getStart());
         $x509->setEndDate($certificatOptionsGenerator->getEnd());
         $x509->setSerialNumber($this->generateSerialNumber(), 10);

--- a/src/X509/X509Generator.php
+++ b/src/X509/X509Generator.php
@@ -33,8 +33,8 @@ class X509Generator
         $subject = $this->generateSubject($publicKey, $options);
         $issuer  = $this->generateIssuer($privateKey, $publicKey, $subject, $options);
         $x509    = new X509();
-        $x509->setStartDate($certificatOptionsGenerator->getStart());
-        $x509->setEndDate($certificatOptionsGenerator->getEnd());
+        $x509->setStartDate($certificatOptionsGenerator->getStart()->format('D, d M Y H:i:s O'));
+        $x509->setEndDate($certificatOptionsGenerator->getEnd()->format('D, d M Y H:i:s O'));
         $x509->setSerialNumber($this->generateSerialNumber(), 10);
 
         $result = $x509->sign($issuer, $subject);

--- a/tests/E2e/Command/E2eTestBase.php
+++ b/tests/E2e/Command/E2eTestBase.php
@@ -11,7 +11,6 @@ use DOMDocument;
 use DOMNode;
 use DOMNodeList;
 use DOMXpath;
-use phpseclib\Crypt\RSA;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -21,9 +20,11 @@ use function assert;
 use function base64_decode;
 use function base64_encode;
 use function bin2hex;
-use function define;
-use function defined;
 use function hash;
+use function openssl_pkey_get_private;
+use function openssl_private_encrypt;
+
+use const OPENSSL_PKCS1_PADDING;
 use function print_r;
 use function sprintf;
 use function trim;
@@ -75,17 +76,16 @@ class E2eTestBase extends TestCase
             };
 
             $crpyt = static function ($ciphertext) {
-                $rsa = new RSA();
-                $rsa->setPassword('');
-                $rsa->loadKey(FakeCrypt::RSA_PRIVATE_KEY, RSA::PRIVATE_FORMAT_PKCS1);
+                $privateKeyRes = openssl_pkey_get_private(FakeCrypt::RSA_PRIVATE_KEY);
+                assert($privateKeyRes !== false);
+                openssl_private_encrypt(
+                    (new AddRsaSha256PrefixAndReturnAsBinary())->__invoke($ciphertext),
+                    $encrypted,
+                    $privateKeyRes,
+                    OPENSSL_PKCS1_PADDING,
+                );
 
-                if (! defined('CRYPT_RSA_PKCS15_COMPAT')) {
-                    define('CRYPT_RSA_PKCS15_COMPAT', true);
-                }
-
-                $rsa->setEncryptionMode(RSA::ENCRYPTION_PKCS1);
-
-                return $rsa->encrypt((new AddRsaSha256PrefixAndReturnAsBinary())->__invoke($ciphertext));
+                return $encrypted;
             };
 
             $signatureOk = static function ($signatureRaw, $signatureValue) use ($crpyt) {
@@ -120,11 +120,13 @@ class E2eTestBase extends TestCase
                 return trim($result);
             };
 
+            $digestValue    = $findElement($xml, 'DigestValue')->nodeValue ?? '';
+            $signatureValue = $findElement($xml, 'SignatureValue')->nodeValue ?? '';
             self::assertTrue(
-                $digestOk($xpathElement($xml, "//*[@authenticate='true']"), $findElement($xml, 'DigestValue')->nodeValue),
-                $digestDump($xpathElement($xml, "//*[@authenticate='true']"), $findElement($xml, 'DigestValue')->nodeValue),
+                $digestOk($xpathElement($xml, "//*[@authenticate='true']"), $digestValue),
+                $digestDump($xpathElement($xml, "//*[@authenticate='true']"), $digestValue),
             );
-            self::assertTrue($signatureOk($findElement($xml, 'SignedInfo')->C14N(), $findElement($xml, 'SignatureValue')->nodeValue));
+            self::assertTrue($signatureOk($findElement($xml, 'SignedInfo')->C14N(), $signatureValue));
         };
     }
 }

--- a/tests/E2e/Command/E2eTestBase.php
+++ b/tests/E2e/Command/E2eTestBase.php
@@ -23,11 +23,11 @@ use function bin2hex;
 use function hash;
 use function openssl_pkey_get_private;
 use function openssl_private_encrypt;
-
-use const OPENSSL_PKCS1_PADDING;
 use function print_r;
 use function sprintf;
 use function trim;
+
+use const OPENSSL_PKCS1_PADDING;
 
 class E2eTestBase extends TestCase
 {

--- a/tests/E2e/Command/FDLCommandTest.php
+++ b/tests/E2e/Command/FDLCommandTest.php
@@ -213,7 +213,7 @@ class FDLCommandTest extends E2eTestBase
         $sUTA->__invoke($response);
     }
 
-    /** @dataProvider provideVersion */
+    /** @DataProvider provideVersion */
     public function testReturnNull(Version $version): void
     {
         $tkey  = 'uBrH173GUziiFUQLBQ7MmlCVCoUqOSxj08hEfiSAxkv9RW2uFJes4jXvn1CVD9Kfa0ot8nG7QIb8aWKaix3XdPFbG5gSbZIk2bGowj5FsijwkCDiBFzSsJhpHskIq2crLDk5c4LzVXrEQBJvUIoQ70OdXzJc8/nhThhkG8hJgGMJH35we0JCqzTcQP8DsdjtApX+HN1UnCdPsmhU2vXR2BpvIDgIluJT/dnzWfp5mhfaGKIMA3+Ow+EEuzrwY8JRAP/P9RYyfptjdsNVwUgb9X6xgAkV805JhIf7g9L3GvJjA1/jhYL2Xj97YC+4dWdswe4WTlrJ+3MPA44Dk3zxrwzv+Iu/66PsAboeW8HB7QEXK6AXxEZq0h6Ng2wSfwJSkZE9UU5xUcFG2S/e41M23ZSBMD/mMy5yadPLhQQ3QBP3bwfgee4bnPky1hwN60yUZdaHvF3z92pStV7GCmxcF9Gt420LGciJ2A9yWDpsxtalmLHzozsIeC687WsOzxN/';

--- a/tests/E2e/Command/FDLCommandTest.php
+++ b/tests/E2e/Command/FDLCommandTest.php
@@ -213,7 +213,7 @@ class FDLCommandTest extends E2eTestBase
         $sUTA->__invoke($response);
     }
 
-    /** @DataProvider provideVersion */
+    /** @dataProvider provideVersion */
     public function testReturnNull(Version $version): void
     {
         $tkey  = 'uBrH173GUziiFUQLBQ7MmlCVCoUqOSxj08hEfiSAxkv9RW2uFJes4jXvn1CVD9Kfa0ot8nG7QIb8aWKaix3XdPFbG5gSbZIk2bGowj5FsijwkCDiBFzSsJhpHskIq2crLDk5c4LzVXrEQBJvUIoQ70OdXzJc8/nhThhkG8hJgGMJH35we0JCqzTcQP8DsdjtApX+HN1UnCdPsmhU2vXR2BpvIDgIluJT/dnzWfp5mhfaGKIMA3+Ow+EEuzrwY8JRAP/P9RYyfptjdsNVwUgb9X6xgAkV805JhIf7g9L3GvJjA1/jhYL2Xj97YC+4dWdswe4WTlrJ+3MPA44Dk3zxrwzv+Iu/66PsAboeW8HB7QEXK6AXxEZq0h6Ng2wSfwJSkZE9UU5xUcFG2S/e41M23ZSBMD/mMy5yadPLhQQ3QBP3bwfgee4bnPky1hwN60yUZdaHvF3z92pStV7GCmxcF9Gt420LGciJ2A9yWDpsxtalmLHzozsIeC687WsOzxN/';

--- a/tests/E2e/Command/FDLCommandTest.php
+++ b/tests/E2e/Command/FDLCommandTest.php
@@ -34,8 +34,8 @@ class FDLCommandTest extends E2eTestBase
     #[DataProvider('provideVersion')]
     public function testOk(Version $version): void
     {
-        $tkey  = 'uBrH173GUziiFUQLBQ7MmlCVCoUqOSxj08hEfiSAxkv9RW2uFJes4jXvn1CVD9Kfa0ot8nG7QIb8aWKaix3XdPFbG5gSbZIk2bGowj5FsijwkCDiBFzSsJhpHskIq2crLDk5c4LzVXrEQBJvUIoQ70OdXzJc8/nhThhkG8hJgGMJH35we0JCqzTcQP8DsdjtApX+HN1UnCdPsmhU2vXR2BpvIDgIluJT/dnzWfp5mhfaGKIMA3+Ow+EEuzrwY8JRAP/P9RYyfptjdsNVwUgb9X6xgAkV805JhIf7g9L3GvJjA1/jhYL2Xj97YC+4dWdswe4WTlrJ+3MPA44Dk3zxrwzv+Iu/66PsAboeW8HB7QEXK6AXxEZq0h6Ng2wSfwJSkZE9UU5xUcFG2S/e41M23ZSBMD/mMy5yadPLhQQ3QBP3bwfgee4bnPky1hwN60yUZdaHvF3z92pStV7GCmxcF9Gt420LGciJ2A9yWDpsxtalmLHzozsIeC687WsOzxN/';
-        $odata = '8jGZE4A8/CEsmzl4kBNVcbDm+QmBpAMtZhCspu8sSL4GxDBmEEj06Yr+8L30bf6TjtSOJiDeeqnnakVCUvTy2YJMTY8aaSF+OwE/iEclqyRtayCjXxkt/073WwPWlE7P0rRrLzGW/n7BCRJW3ffuMw==';
+        $tkey  = 'pCRLrJHNXCDLa1AUhBN/tN0hmoZn6eEetISPUlr4Igg0EmkMQ+v7ZKjT2yuL44J5m0z7fuhnHCMSzDKlCzZGTtTBrLoal9KVzZdMWzKcUIHuTXkOyHOuuTe5RgMgBR2QsgR9Tna9p0oUmBsPRWttV0/CAeEb+R6AHuZkuVZgdx0=';
+        $odata = 'pF7sOOXT+xNYNTsWgvdeg5baJSoJz/J68YhOCYno2TUPuP6cRxdd34oT4VgGtqLDU6y35+RrOGUUlzP194uVTEUh9YwaXy9mZklbn+seGnySzBvHw8qLy4xntXOS7LscJrFlL3k/NUtd6m7uJLVEPA==';
 
         $v24 = '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ebicsResponse xmlns="http://www.ebics.org/H003" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="H003" xsi:schemaLocation="http://www.ebics.org/H003 http://www.ebics.org/H003/ebics_response.xsd">
@@ -216,8 +216,8 @@ class FDLCommandTest extends E2eTestBase
     /** @dataProvider provideVersion */
     public function testReturnNull(Version $version): void
     {
-        $tkey  = 'uBrH173GUziiFUQLBQ7MmlCVCoUqOSxj08hEfiSAxkv9RW2uFJes4jXvn1CVD9Kfa0ot8nG7QIb8aWKaix3XdPFbG5gSbZIk2bGowj5FsijwkCDiBFzSsJhpHskIq2crLDk5c4LzVXrEQBJvUIoQ70OdXzJc8/nhThhkG8hJgGMJH35we0JCqzTcQP8DsdjtApX+HN1UnCdPsmhU2vXR2BpvIDgIluJT/dnzWfp5mhfaGKIMA3+Ow+EEuzrwY8JRAP/P9RYyfptjdsNVwUgb9X6xgAkV805JhIf7g9L3GvJjA1/jhYL2Xj97YC+4dWdswe4WTlrJ+3MPA44Dk3zxrwzv+Iu/66PsAboeW8HB7QEXK6AXxEZq0h6Ng2wSfwJSkZE9UU5xUcFG2S/e41M23ZSBMD/mMy5yadPLhQQ3QBP3bwfgee4bnPky1hwN60yUZdaHvF3z92pStV7GCmxcF9Gt420LGciJ2A9yWDpsxtalmLHzozsIeC687WsOzxN/';
-        $odata = '8jGZE4A8/CEsmzl4kBNVcbDm+QmBpAMtZhCspu8sSL4GxDBmEEj06Yr+8L30bf6TjtSOJiDeeqnnakVCUvTy2YJMTY8aaSF+OwE/iEclqyRtayCjXxkt/073WwPWlE7P0rRrLzGW/n7BCRJW3ffuMw==';
+        $tkey  = 'pCRLrJHNXCDLa1AUhBN/tN0hmoZn6eEetISPUlr4Igg0EmkMQ+v7ZKjT2yuL44J5m0z7fuhnHCMSzDKlCzZGTtTBrLoal9KVzZdMWzKcUIHuTXkOyHOuuTe5RgMgBR2QsgR9Tna9p0oUmBsPRWttV0/CAeEb+R6AHuZkuVZgdx0=';
+        $odata = 'pF7sOOXT+xNYNTsWgvdeg5baJSoJz/J68YhOCYno2TUPuP6cRxdd34oT4VgGtqLDU6y35+RrOGUUlzP194uVTEUh9YwaXy9mZklbn+seGnySzBvHw8qLy4xntXOS7LscJrFlL3k/NUtd6m7uJLVEPA==';
 
         $v24 = '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ebicsResponse xmlns="http://www.ebics.org/H003" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="H003" xsi:schemaLocation="http://www.ebics.org/H003 http://www.ebics.org/H003/ebics_response.xsd">

--- a/tests/E2e/Command/HPBCommandTest.php
+++ b/tests/E2e/Command/HPBCommandTest.php
@@ -33,8 +33,8 @@ class HPBCommandTest extends E2eTestBase
     {
         // encryt TransactionKey with FakeCrypt::RSA_PUBLIC_KEY
 
-        $tkey  = 'uBrH173GUziiFUQLBQ7MmlCVCoUqOSxj08hEfiSAxkv9RW2uFJes4jXvn1CVD9Kfa0ot8nG7QIb8aWKaix3XdPFbG5gSbZIk2bGowj5FsijwkCDiBFzSsJhpHskIq2crLDk5c4LzVXrEQBJvUIoQ70OdXzJc8/nhThhkG8hJgGMJH35we0JCqzTcQP8DsdjtApX+HN1UnCdPsmhU2vXR2BpvIDgIluJT/dnzWfp5mhfaGKIMA3+Ow+EEuzrwY8JRAP/P9RYyfptjdsNVwUgb9X6xgAkV805JhIf7g9L3GvJjA1/jhYL2Xj97YC+4dWdswe4WTlrJ+3MPA44Dk3zxrwzv+Iu/66PsAboeW8HB7QEXK6AXxEZq0h6Ng2wSfwJSkZE9UU5xUcFG2S/e41M23ZSBMD/mMy5yadPLhQQ3QBP3bwfgee4bnPky1hwN60yUZdaHvF3z92pStV7GCmxcF9Gt420LGciJ2A9yWDpsxtalmLHzozsIeC687WsOzxN/';
-        $odata = '8jGZE4A8/CEsmzl4kBNVcbDm+QmBpAMtZhCspu8sSL4GxDBmEEj06Yr+8L30bf6TjtSOJiDeeqnnakVCUvTy2YJMTY8aaSF+OwE/iEclqyRtayCjXxkt/073WwPWlE7P0rRrLzGW/n7BCRJW3ffuMw==';
+        $tkey  = 'pCRLrJHNXCDLa1AUhBN/tN0hmoZn6eEetISPUlr4Igg0EmkMQ+v7ZKjT2yuL44J5m0z7fuhnHCMSzDKlCzZGTtTBrLoal9KVzZdMWzKcUIHuTXkOyHOuuTe5RgMgBR2QsgR9Tna9p0oUmBsPRWttV0/CAeEb+R6AHuZkuVZgdx0=';
+        $odata = 'pF7sOOXT+xNYNTsWgvdeg5baJSoJz/J68YhOCYno2TUPuP6cRxdd34oT4VgGtqLDU6y35+RrOGUUlzP194uVTEUh9YwaXy9mZklbn+seGnySzBvHw8qLy4xntXOS7LscJrFlL3k/NUtd6m7uJLVEPA==';
 
         $versionToXmlResponse = [
             Version::v24()->value() => '<?xml version="1.0" encoding="UTF-8" standalone="no"?><ebicsKeyManagementResponse xmlns="http://www.ebics.org/H003" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Revision="1" Version="H003" xsi:schemaLocation="http://www.ebics.org/H003 http://www.ebics.org/H003/ebics_keymgmt_response.xsd"><header authenticate="true"><static/><mutable><ReturnCode>000000</ReturnCode><ReportText>[EBICS_OK] OK</ReportText></mutable></header><body><DataTransfer><DataEncryptionInfo authenticate="true"><EncryptionPubKeyDigest Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" Version="E002">kWJ3YXAUrfQTbtJRQ5XM1CrN1LbifEAVpo77BYpXEv0=</EncryptionPubKeyDigest><TransactionKey>' . $tkey . '</TransactionKey></DataEncryptionInfo><OrderData>' . $odata . '</OrderData></DataTransfer><ReturnCode authenticate="true">000000</ReturnCode></body></ebicsKeyManagementResponse>',

--- a/tests/Functional/CryptAndDecryptDataTest.php
+++ b/tests/Functional/CryptAndDecryptDataTest.php
@@ -17,7 +17,13 @@ use phpseclib3\Crypt\RSA;
 use phpseclib3\Crypt\RSA\PublicKey as RsaPublicKey;
 use PHPUnit\Framework\TestCase;
 
+use function assert;
+use function base64_encode;
 use function gzcompress;
+use function random_bytes;
+use function str_pad;
+use function str_repeat;
+use function strlen;
 
 class CryptAndDecryptDataTest extends TestCase
 {
@@ -32,8 +38,8 @@ class CryptAndDecryptDataTest extends TestCase
         $certE  = $generateCert->__invoke(new DefaultX509OptionGenerator(), $password, CertificatType::e());
         $aesKey = random_bytes(16);
 
-        /** @var RsaPublicKey $pubKey */
-        $pubKey         = RSA::loadPublicKey($certE->getPublicKey());
+        $pubKey = RSA::loadPublicKey($certE->getPublicKey());
+        assert($pubKey instanceof RsaPublicKey);
         $transactionKey = $pubKey->withPadding(RSA::ENCRYPTION_PKCS1)->encrypt($aesKey);
 
         $orderData = base64_encode($this->aesCrypt($aesKey, self::gzcompress($xmlData)));
@@ -55,7 +61,7 @@ class CryptAndDecryptDataTest extends TestCase
         $blockSize = 16;
         $remainder = strlen($cypher) % $blockSize;
         if ($remainder !== 0) {
-            $cypher = str_pad($cypher, strlen($cypher) + ($blockSize - $remainder), "\0");
+            $cypher = str_pad($cypher, strlen($cypher) + $blockSize - $remainder, "\0");
         }
 
         return $aes->encrypt($cypher);

--- a/tests/Functional/CryptAndDecryptDataTest.php
+++ b/tests/Functional/CryptAndDecryptDataTest.php
@@ -38,8 +38,8 @@ class CryptAndDecryptDataTest extends TestCase
         $certE  = $generateCert->__invoke(new DefaultX509OptionGenerator(), $password, CertificatType::e());
         $aesKey = random_bytes(16);
 
-        $pubKey = RSA::loadPublicKey($certE->getPublicKey());
-        assert($pubKey instanceof RsaPublicKey);
+        /** @var RsaPublicKey $pubKey */
+        $pubKey = RSA::load($certE->getPublicKey());
         $transactionKey = $pubKey->withPadding(RSA::ENCRYPTION_PKCS1)->encrypt($aesKey);
 
         $orderData = base64_encode($this->aesCrypt($aesKey, self::gzcompress($xmlData)));

--- a/tests/Functional/CryptAndDecryptDataTest.php
+++ b/tests/Functional/CryptAndDecryptDataTest.php
@@ -5,38 +5,38 @@ declare(strict_types=1);
 namespace Cube43\Component\Ebics\Tests\Functional;
 
 use Cube43\Component\Ebics\CertificatType;
-use Cube43\Component\Ebics\Crypt\AddRsaSha256PrefixAndReturnAsBinary;
 use Cube43\Component\Ebics\Crypt\DecryptOrderDataContent;
-use Cube43\Component\Ebics\Crypt\EncrytSignatureValueWithUserPrivateKey;
 use Cube43\Component\Ebics\Crypt\GenerateCertificat;
 use Cube43\Component\Ebics\DOMDocument;
 use Cube43\Component\Ebics\KeyRing;
 use Cube43\Component\Ebics\OrderDataEncrypted;
-use Cube43\Component\Ebics\PrivateKey;
 use Cube43\Component\Ebics\X509\DefaultX509OptionGenerator;
 use ErrorException;
-use phpseclib\Crypt\AES;
+use phpseclib3\Crypt\AES;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\RSA\PublicKey as RsaPublicKey;
 use PHPUnit\Framework\TestCase;
 
 use function gzcompress;
-
-use const OPENSSL_ZERO_PADDING;
 
 class CryptAndDecryptDataTest extends TestCase
 {
     public function testFail(): void
     {
         $generateCert            = new GenerateCertificat();
-        $encrypted               = new EncrytSignatureValueWithUserPrivateKey();
         $decryptOrderDataContent = new DecryptOrderDataContent();
         $password                = new KeyRing('myPass');
 
         $xmlData = '<test><AuthenticationPubKeyInfo><X509Certificate>test</X509Certificate><Modulus>test</Modulus><Exponent>test</Exponent></AuthenticationPubKeyInfo><EncryptionPubKeyInfo><X509Certificate>test</X509Certificate><Modulus>test</Modulus><Exponent>test</Exponent></EncryptionPubKeyInfo></test>';
 
-        $certE          = $generateCert->__invoke(new DefaultX509OptionGenerator(), $password, CertificatType::e());
-        $transactionKey = $encrypted->__invoke($password, new PrivateKey($certE->getPublicKey()), $xmlData);
+        $certE  = $generateCert->__invoke(new DefaultX509OptionGenerator(), $password, CertificatType::e());
+        $aesKey = random_bytes(16);
 
-        $orderData = $this->aesCrypt((new AddRsaSha256PrefixAndReturnAsBinary())->__invoke($xmlData), self::gzcompress($xmlData));
+        /** @var RsaPublicKey $pubKey */
+        $pubKey         = RSA::loadPublicKey($certE->getPublicKey());
+        $transactionKey = $pubKey->withPadding(RSA::ENCRYPTION_PKCS1)->encrypt($aesKey);
+
+        $orderData = base64_encode($this->aesCrypt($aesKey, self::gzcompress($xmlData)));
 
         $keyRing = new KeyRing('myPass');
         $keyRing = $keyRing->setUserCertificateEAndX($certE, $certE);
@@ -46,12 +46,17 @@ class CryptAndDecryptDataTest extends TestCase
 
     private function aesCrypt(string $key, string $cypher): string
     {
-        $aes = new AES(AES::MODE_CBC);
+        $aes = new AES('cbc');
         $aes->setKeyLength(128);
         $aes->setKey($key);
+        $aes->setIV(str_repeat("\0", 16));
+        $aes->disablePadding();
 
-        // phpcs:ignore
-        $aes->openssl_options = OPENSSL_ZERO_PADDING;
+        $blockSize = 16;
+        $remainder = strlen($cypher) % $blockSize;
+        if ($remainder !== 0) {
+            $cypher = str_pad($cypher, strlen($cypher) + ($blockSize - $remainder), "\0");
+        }
 
         return $aes->encrypt($cypher);
     }

--- a/tests/Functional/CryptAndDecryptDataTest.php
+++ b/tests/Functional/CryptAndDecryptDataTest.php
@@ -38,8 +38,8 @@ class CryptAndDecryptDataTest extends TestCase
         $certE  = $generateCert->__invoke(new DefaultX509OptionGenerator(), $password, CertificatType::e());
         $aesKey = random_bytes(16);
 
-        /** @var RsaPublicKey $pubKey */
         $pubKey = RSA::load($certE->getPublicKey());
+        assert($pubKey instanceof RsaPublicKey);
         $transactionKey = $pubKey->withPadding(RSA::ENCRYPTION_PKCS1)->encrypt($aesKey);
 
         $orderData = base64_encode($this->aesCrypt($aesKey, self::gzcompress($xmlData)));

--- a/tests/Unit/UserCertificateTest.php
+++ b/tests/Unit/UserCertificateTest.php
@@ -9,8 +9,11 @@ use Cube43\Component\Ebics\CertificatType;
 use Cube43\Component\Ebics\Crypt\ExponentAndModulus;
 use Cube43\Component\Ebics\Models\Certificate;
 use Cube43\Component\Ebics\PrivateKey;
+use Cube43\Component\Ebics\Tests\E2e\FakeCrypt;
 use Cube43\Component\Ebics\UserCertificate;
 use PHPUnit\Framework\TestCase;
+
+use function base64_encode;
 
 /** @coversDefaultClass Certificate */
 class UserCertificateTest extends TestCase
@@ -25,16 +28,16 @@ class UserCertificateTest extends TestCase
         $certificateX509->expects(self::once())->method('value')->willReturn('certX509');
         $certificatType->expects(self::once())->method('value')->willReturn('typea');
 
-        $sUT = new UserCertificate($certificatType, 'test2', $privateKey, $certificateX509);
+        $sUT = new UserCertificate($certificatType, FakeCrypt::RSA_PUBLIC_KEY, $privateKey, $certificateX509);
 
         self::assertSame($certificatType, $sUT->getCertificatType());
-        self::assertSame('test2', $sUT->getPublicKey());
+        self::assertSame(FakeCrypt::RSA_PUBLIC_KEY, $sUT->getPublicKey());
         self::assertSame($privateKey, $sUT->getPrivateKey());
         self::assertSame($certificateX509, $sUT->getCertificatX509());
         self::assertInstanceOf(ExponentAndModulus::class, $sUT->getPublicKeyDetails());
         self::assertEquals([
             'type' => 'typea',
-            'public' => 'dGVzdDI=',
+            'public' => base64_encode(FakeCrypt::RSA_PUBLIC_KEY),
             'private' => 'cHJpdmF0ZUtleQ==',
             'content' => 'Y2VydFg1MDk=',
         ], $sUT->jsonSerialize());


### PR DESCRIPTION
Permet de gérer les certificats PEM et DER.
Si DER est détecté (pas de délimiteurs ---BEGIN CERTIFICATE---) alors, le certificat est converti.

la méthode CertificateX509::fingerprint() devient fonctionnelle dans les 2 cas et la méthode CertificateX509::digest() devient donc obsolète